### PR TITLE
chore: hybr-eat to 0.0.9

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,7 +9,7 @@ dependencies:
   version: 2.3.89
 - name: hybr-eat
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.5
+  version: 0.0.9
 - name: test-spring
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.3


### PR DESCRIPTION
chore: Promote hybr-eat to version 0.0.9