### PR TITLE
chore: hybrit-app-generic-env-config to 0.0.6

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -12,7 +12,7 @@ dependencies:
   version: 0.0.22
 - name: hybrit-app-generic-env-config
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.5
+  version: 0.0.6
 - name: redis-db
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.7


### PR DESCRIPTION
chore: Promote hybrit-app-generic-env-config to version 0.0.6